### PR TITLE
Add arrays to the input of ExecuteDLLCommand

### DIFF
--- a/taskt/Core/Automation/Commands/ExecuteDLLCommand.cs
+++ b/taskt/Core/Automation/Commands/ExecuteDLLCommand.cs
@@ -183,6 +183,11 @@ namespace taskt.Core.Automation.Commands
                         var parseResult = DateTime.Parse(requiredParameterValue);
                         parameters.Add(parseResult);
                     }
+                    else if ((param.ParameterType.IsArray))
+                    {
+                        var parseResult = requiredParameterValue.Split(new char[] {','},StringSplitOptions.RemoveEmptyEntries);
+                        parameters.Add(parseResult);
+                    }
                     else
                     {
                         throw new NotImplementedException("Only system parameter types are supported!");


### PR DESCRIPTION
Added lines from line 186 to 190; to let user use arrays as an input parameter of the DLL command in the form of "value1,value2,value3" without double quotes.