### PR TITLE
Keep custom separators across cultures

### DIFF
--- a/taskt/Core/Automation/Commands/Data/DateCalculationCommand.cs
+++ b/taskt/Core/Automation/Commands/Data/DateCalculationCommand.cs
@@ -1,7 +1,9 @@
 ﻿using System;
-using System.Xml.Serialization;
-using System.IO;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml.Serialization;
 using System.Windows.Forms;
 using taskt.UI.Forms;
 using taskt.UI.CustomControls;
@@ -147,6 +149,7 @@ namespace taskt.Core.Automation.Commands
 
             //handle if formatter is required     
             var formatting = v_ToStringFormat.ConvertToUserVariable(sender);
+            formatting = Regex.Replace(formatting, @"[.,:;\/\\]", x => $"'{x}'");
             var stringDateFormatted = requiredDateTime.ToString(formatting);
 
 


### PR DESCRIPTION
This changes all the seperators I could reasonably think of for dates and times to the intended custom `'[separator]'` format, keeping them across different system culture settings. This way they reflect the UI input instead of being accidentally converted. See #280 for reasoning.